### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "libicu"
+description := "International Components for Unicode"
+gitrepo     := "https://chromium.googlesource.com/chromium/deps/icu.git"
+homepage    := "https://icu.unicode.org/"
+version     := chromium/63staging sha256:ea3dff2a0fcac987c72cf234c0b5be3641cf08752faa9968ecf10de073d04884 https://chromium.googlesource.com/chromium/deps/icu.git/+archive/chromium/63staging.tar.gz
+license     := "Unicode-DFS-2016"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

